### PR TITLE
add codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,10 @@ jobs:
         cache: true
 
     - name: Run unit tests
-      run: make test-unit
+      run: go test -v ./... -coverprofile=coverage.out
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out
+        fail_ci_if_error: false


### PR DESCRIPTION
This pull request updates the CI workflow to improve test coverage reporting and integration with Codecov. The main change is replacing the previous unit test command with a more detailed test run that generates a coverage report, and then uploading that report to Codecov.

Testing and coverage improvements:

* Replaced the `make test-unit` command with `go test -v ./... -coverprofile=coverage.out` to run all unit tests and generate a coverage report.
* Added a step to upload the generated coverage report to Codecov using the `codecov/codecov-action@v5` GitHub Action, with the necessary token and file configuration.