### PR TITLE
Define constants for curve calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint:
 lint-install:
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Installing golangci-lint..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
 	fi
 	golangci-lint run --timeout=5m
 

--- a/ftls/dict.go
+++ b/ftls/dict.go
@@ -167,18 +167,32 @@ var DefaultCurves = []CurveID{
 	CurveP384,
 	CurveP256}
 
+const (
+	curveX25519         = "X25519"
+	curveP256           = "P-256"
+	curveP384           = "P-384"
+	curveP521           = "P-521"
+	curveDH1024         = "DH-1024"
+	curveDH2048         = "DH-2048"
+	curveDH3072         = "DH-3072"
+	curveDH4096         = "DH-4096"
+	curveDH6144         = "DH-6144"
+	curveDH8192         = "DH-8192"
+	curveX25519MLKEM768 = "X25519-ML-KEM-768"
+)
+
 var CurveIDToName = map[CurveID]string{
-	X25519:         "X25519",
-	CurveP256:      "P-256",
-	CurveP384:      "P-384",
-	CurveP521:      "P-521",
-	DH1024:         "DH-1024",
-	DH2048:         "DH-2048",
-	DH3072:         "DH-3072",
-	DH4096:         "DH-4096",
-	DH6144:         "DH-6144",
-	DH8192:         "DH-8192",
-	X25519MLKEM768: "X25519-ML-KEM-768",
+	X25519:         curveX25519,
+	CurveP256:      curveP256,
+	CurveP384:      curveP384,
+	CurveP521:      curveP521,
+	DH1024:         curveDH1024,
+	DH2048:         curveDH2048,
+	DH3072:         curveDH3072,
+	DH4096:         curveDH4096,
+	DH6144:         curveDH6144,
+	DH8192:         curveDH8192,
+	X25519MLKEM768: curveX25519MLKEM768,
 }
 
 var ProtocolToName = map[int]string{

--- a/ftls/handshake_messages.go
+++ b/ftls/handshake_messages.go
@@ -1045,16 +1045,16 @@ func (m *ServerKeyExchangeMsg) GetKey() error {
 		// Get the curve name and key size
 		switch curveID {
 		case X25519:
-			m.KeyType, m.KeySize, m.CurveID = "X25519", 32, curveID
+			m.KeyType, m.KeySize, m.CurveID = curveX25519, 32, curveID
 			return nil
 		case CurveP256:
-			m.KeyType, m.KeySize, m.CurveID = "P-256", 32, curveID
+			m.KeyType, m.KeySize, m.CurveID = curveP256, 32, curveID
 			return nil
 		case CurveP384:
-			m.KeyType, m.KeySize, m.CurveID = "P-384", 48, curveID
+			m.KeyType, m.KeySize, m.CurveID = curveP384, 48, curveID
 			return nil
 		case CurveP521:
-			m.KeyType, m.KeySize, m.CurveID = "P-521", 66, curveID
+			m.KeyType, m.KeySize, m.CurveID = curveP521, 66, curveID
 			return nil
 		default:
 			return fmt.Errorf("unknown curve (0x%04x)", curveID)
@@ -1073,22 +1073,22 @@ func (m *ServerKeyExchangeMsg) GetKey() error {
 			// Identify common DH groups by their prime size and specific values
 			switch len(dhP) {
 			case 128: // 1024 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-1024", 128, DH1024
+				m.KeyType, m.KeySize, m.CurveID = curveDH1024, 128, DH1024
 				return nil
 			case 256: // 2048 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-2048", 256, DH2048
+				m.KeyType, m.KeySize, m.CurveID = curveDH2048, 256, DH2048
 				return nil
 			case 384: // 3072 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-3072", 384, DH3072
+				m.KeyType, m.KeySize, m.CurveID = curveDH3072, 384, DH3072
 				return nil
 			case 512: // 4096 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-4096", 512, DH4096
+				m.KeyType, m.KeySize, m.CurveID = curveDH4096, 512, DH4096
 				return nil
 			case 768: // 6144 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-6144", 768, DH6144
+				m.KeyType, m.KeySize, m.CurveID = curveDH6144, 768, DH6144
 				return nil
 			case 1024: // 8192 bits
-				m.KeyType, m.KeySize, m.CurveID = "DH-8192", 1024, DH8192
+				m.KeyType, m.KeySize, m.CurveID = curveDH8192, 1024, DH8192
 				return nil
 			default:
 				return fmt.Errorf("DH-%d", len(dhP)*8)


### PR DESCRIPTION
This pull request refactors how elliptic curve and Diffie-Hellman group names are handled throughout the codebase to improve consistency and maintainability. It introduces string constants for curve names, updates their usage in mapping tables and key handling logic, and also updates the `Makefile` to use the correct import path for `golangci-lint`.

Refactoring for curve and group name handling:

* Added string constants (e.g., `curveX25519`, `curveP256`, etc.) for all supported curve and DH group names in `ftls/dict.go`, and updated `CurveIDToName` to use these constants instead of hardcoded strings.
* Updated `ServerKeyExchangeMsg.GetKey()` in `ftls/handshake_messages.go` to use the new string constants when setting `KeyType` for both elliptic curves and DH groups, ensuring consistent naming across the codebase. [[1]](diffhunk://#diff-88063c1543df4fb630eea32de1d85d87ed95c683028906e0871b99a95ec7ceebL1048-R1057) [[2]](diffhunk://#diff-88063c1543df4fb630eea32de1d85d87ed95c683028906e0871b99a95ec7ceebL1076-R1091)

Tooling update:

* Updated the `Makefile` to use the correct v2 import path for installing `golangci-lint`.