### PR TITLE
Add unit tests for ftls module

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -15,7 +15,7 @@ This document describes how to run the unit and integration tests for the TLS Si
 Unit tests reside within their respective packages:
 
 - **Simulator Unit Tests** (`simulator/simulator_test.go`): Tests handshake orchestration (`PerformTLSHandshake`), ClientHello formatting, record construction, response parsing, message extraction, and network timeout handling.
-- **FTLS Message Tests** (`ftls/handshake_messages_test.go`): Tests marshaling and unmarshaling of TLS handshake messages (`ServerHello`, `Finished`, `ServerKeyExchange`).
+- **FTLS Message Tests** (`ftls/handshake_messages_test.go`): Tests marshaling and unmarshaling of TLS handshake messages (`ClientHello`, `ServerHello`, `Finished`, `ServerKeyExchange`), including extension-heavy and malformed-message cases.
 
 ### Integration Tests
 
@@ -83,6 +83,59 @@ Tests helper function checking `net.Error.Timeout()`.
 - **`net error with timeout false`**: Confirms `isTimeoutError` returns `false` for a mock `net.Error` with `Timeout() == false`.
 - **`standard non-net error`**: Confirms `isTimeoutError` returns `false` for standard Go `error` objects.
 
+## FTLS Package Unit Tests (`ftls/handshake_messages_test.go`)
+
+### `TestFinishedMsg`
+
+Tests `Finished` handshake message encoding/decoding for multiple verify-data sizes.
+
+- **`Empty verify data`**: Marshals/unmarshals a zero-length verify payload.
+- **`12-byte verify data (TLS 1.2)`**: Verifies classic TLS 1.2 `Finished` payload length.
+- **`32-byte verify data (TLS 1.3)`**: Verifies larger TLS 1.3-style verify payload length.
+
+### `TestServerHelloMsg` and `TestServerHelloMarshalUnmarshalWithExtensions`
+
+Tests both basic and extension-rich `ServerHello` marshal/unmarshal paths.
+
+- **Basic handshake cases**: Valid TLS 1.2 and TLS 1.3 messages plus malformed/truncated inputs.
+- **Extension-rich round trip**: OCSP, session ticket, renegotiation info, extended master secret, ALPN, SCT, supported versions, key share, pre-shared key identity, supported points, ECH payload, and SNI acknowledgment.
+- **`OriginalBytes` behavior**: Confirms unmarshaled message preserves original wire bytes.
+
+### `TestServerHelloUnmarshalHelloRetryRequestKeyShare`
+
+Tests HelloRetryRequest-compatible key_share parsing.
+
+- **Selected group format**: Verifies the 2-byte key_share format is accepted and parsed into `SelectedGroup`.
+
+### `TestClientHelloMarshalUnmarshalFull`
+
+Covers a comprehensive `ClientHello` round trip with most supported extensions enabled.
+
+- **Extensions covered**: SNI, status request, supported curves/points, session ticket, signature algorithms (+ cert), renegotiation info, extended master secret, ALPN, SCT, supported versions, cookie, key share, early data, PSK modes, pre-shared key identities/binders, QUIC transport parameters, and encrypted client hello payload.
+
+### `TestClientHelloMarshalMsgECHInner`
+
+Tests ECH-inner behavior of `ClientHello` marshaling.
+
+- **ECH outer extension list**: Verifies `ECHOuterExtensions` is emitted.
+- **Inner CH constraints**: Verifies direct extension placement and session-id behavior for ECH inner encoding.
+
+### `TestClientHelloUnmarshalRejectsInvalid`
+
+Tests strict validation on malformed `ClientHello` extension state.
+
+- **Trailing-dot SNI rejection**: Confirms hostnames ending with `.` are rejected.
+- **PSK ordering rule**: Confirms `pre_shared_key` must be the final extension.
+
+### `TestServerKeyExchangeMsgGetKey` and `TestServerKeyExchangeMarshalAndUnmarshal`
+
+Tests key extraction and wire-format processing for `ServerKeyExchange`.
+
+- **ECDHE key parsing**: X25519, P-256, and P-384 recognition.
+- **Finite-field DH parsing**: Known DH modulus sizes (e.g., 2048/3072) map to expected group labels.
+- **Error paths**: Unknown curve, invalid key lengths, and short messages.
+- **Marshal safeguards**: Verifies oversized key payloads are rejected.
+
 ## Running Tests
 
 ### Quick Start
@@ -129,6 +182,12 @@ make docker-down
 ```bash
 # Run simulator unit tests with coverage (writes coverage.out)
 go test -v -coverprofile=coverage.out ./simulator/...
+
+# Run FTLS message unit tests only
+go test -v ./ftls -run "Test(FinishedMsg|ServerHelloMsg|ServerHelloMarshalUnmarshalWithExtensions|ServerHelloUnmarshalHelloRetryRequestKeyShare|ClientHelloMarshalUnmarshalFull|ClientHelloMarshalMsgECHInner|ClientHelloUnmarshalRejectsInvalid|ServerKeyExchangeMsgGetKey|ServerKeyExchangeMarshalAndUnmarshal)$"
+
+# Run FTLS unit tests with per-file coverage report
+go test -v -coverprofile=coverage.out ./ftls && go tool cover -func=coverage.out | grep handshake_messages.go
 
 # Run all unit tests (exclude integration_tests, which requires -tags integration)
 go test -v $(go list ./... | grep -v "/integration_tests$")

--- a/ftls/handshake_messages_test.go
+++ b/ftls/handshake_messages_test.go
@@ -439,7 +439,8 @@ func TestClientHelloMarshalUnmarshalFull(t *testing.T) {
 		t.Fatalf("random mismatch")
 	}
 
-	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported || !got.ExtendedMasterSecret || !got.Scts || !got.EarlyData {
+	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported ||
+		!got.ExtendedMasterSecret || !got.Scts || !got.EarlyData {
 		t.Fatalf("expected boolean extensions to round-trip")
 	}
 
@@ -537,6 +538,7 @@ func TestClientHelloUnmarshalRejectsInvalid(t *testing.T) {
 		// Append an extra zero-length unknown extension after pre_shared_key
 		// while updating both handshake and extension length fields.
 		msgData := append([]byte(nil), encoded[4:]...)
+
 		extLenOffset := len(msgData) - 2
 		for i := 0; i+3 < len(msgData); i++ {
 			if i+1 < len(msgData) {
@@ -600,7 +602,8 @@ func TestServerHelloMarshalUnmarshalWithExtensions(t *testing.T) {
 		t.Fatal("Unmarshal() returned false")
 	}
 
-	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported || !got.ExtendedMasterSecret || !got.SelectedIdentityPresent || !got.ServerNameAck {
+	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported ||
+		!got.ExtendedMasterSecret || !got.SelectedIdentityPresent || !got.ServerNameAck {
 		t.Fatalf("expected boolean extension flags to be set")
 	}
 
@@ -644,6 +647,7 @@ func TestServerHelloUnmarshalHelloRetryRequestKeyShare(t *testing.T) {
 func TestServerKeyExchangeMarshalAndUnmarshal(t *testing.T) {
 	t.Run("marshal normal", func(t *testing.T) {
 		msg := &ServerKeyExchangeMsg{Key: []byte{0x01, 0x02, 0x03}}
+
 		encoded, err := msg.Marshal()
 		if err != nil {
 			t.Fatalf("Marshal() error = %v", err)
@@ -657,7 +661,9 @@ func TestServerKeyExchangeMarshalAndUnmarshal(t *testing.T) {
 
 	t.Run("marshal too large", func(t *testing.T) {
 		msg := &ServerKeyExchangeMsg{Key: make([]byte, 0x1000000)}
-		if _, err := msg.Marshal(); err == nil {
+
+		_, err := msg.Marshal()
+		if err == nil {
 			t.Fatal("Marshal() expected error for oversized key")
 		}
 	})

--- a/ftls/handshake_messages_test.go
+++ b/ftls/handshake_messages_test.go
@@ -2,6 +2,7 @@ package ftls
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -382,6 +383,71 @@ func hasExt(exts []uint16, want uint16) bool {
 	return false
 }
 
+func clientHelloExtensionsLenOffset(handshake []byte) (int, error) {
+	if len(handshake) < 4 {
+		return 0, fmt.Errorf("handshake too short")
+	}
+
+	bodyLen := int(handshake[1])<<16 | int(handshake[2])<<8 | int(handshake[3])
+	if bodyLen != len(handshake)-4 {
+		return 0, fmt.Errorf("invalid handshake length: header=%d actual=%d", bodyLen, len(handshake)-4)
+	}
+
+	pos := 4
+	if pos+2+32 > len(handshake) {
+		return 0, fmt.Errorf("missing version/random")
+	}
+
+	pos += 2 + 32 // legacy_version + random
+
+	if pos+1 > len(handshake) {
+		return 0, fmt.Errorf("missing session_id length")
+	}
+
+	sessionIDLen := int(handshake[pos])
+	pos++
+	if pos+sessionIDLen > len(handshake) {
+		return 0, fmt.Errorf("truncated session_id")
+	}
+
+	pos += sessionIDLen
+
+	if pos+2 > len(handshake) {
+		return 0, fmt.Errorf("missing cipher_suites length")
+	}
+
+	cipherSuitesLen := int(handshake[pos])<<8 | int(handshake[pos+1])
+	pos += 2
+	if pos+cipherSuitesLen > len(handshake) {
+		return 0, fmt.Errorf("truncated cipher_suites")
+	}
+
+	pos += cipherSuitesLen
+
+	if pos+1 > len(handshake) {
+		return 0, fmt.Errorf("missing compression_methods length")
+	}
+
+	compressionMethodsLen := int(handshake[pos])
+	pos++
+	if pos+compressionMethodsLen > len(handshake) {
+		return 0, fmt.Errorf("truncated compression_methods")
+	}
+
+	pos += compressionMethodsLen
+
+	if pos+2 > len(handshake) {
+		return 0, fmt.Errorf("missing extensions length")
+	}
+
+	extensionsLen := int(handshake[pos])<<8 | int(handshake[pos+1])
+	if pos+2+extensionsLen != len(handshake) {
+		return 0, fmt.Errorf("invalid extensions vector length")
+	}
+
+	return pos, nil
+}
+
 func TestClientHelloMarshalUnmarshalFull(t *testing.T) {
 	msg := &ClientHelloMsg{
 		Vers:               VersionTLS12,
@@ -537,29 +603,22 @@ func TestClientHelloUnmarshalRejectsInvalid(t *testing.T) {
 
 		// Append an extra zero-length unknown extension after pre_shared_key
 		// while updating both handshake and extension length fields.
-		msgData := append([]byte(nil), encoded[4:]...)
+		encoded = append([]byte(nil), encoded...)
 
-		extLenOffset := len(msgData) - 2
-		for i := 0; i+3 < len(msgData); i++ {
-			if i+1 < len(msgData) {
-				extLen := int(msgData[i])<<8 | int(msgData[i+1])
-				if i+2+extLen == len(msgData) {
-					extLenOffset = i
-					break
-				}
-			}
+		extLenOffset, err := clientHelloExtensionsLenOffset(encoded)
+		if err != nil {
+			t.Fatalf("failed to locate extensions length: %v", err)
 		}
 
-		extLen := int(msgData[extLenOffset])<<8 | int(msgData[extLenOffset+1])
-		msgData[extLenOffset] = byte((extLen + 4) >> 8)
-		msgData[extLenOffset+1] = byte(extLen + 4)
-		msgData = append(msgData, 0xFA, 0xCE, 0x00, 0x00)
+		extLen := int(encoded[extLenOffset])<<8 | int(encoded[extLenOffset+1])
+		encoded[extLenOffset] = byte((extLen + 4) >> 8)
+		encoded[extLenOffset+1] = byte(extLen + 4)
+		encoded = append(encoded, 0xFA, 0xCE, 0x00, 0x00)
 
-		handshakeLen := len(msgData)
+		handshakeLen := len(encoded) - 4
 		encoded[1] = byte(handshakeLen >> 16)
 		encoded[2] = byte(handshakeLen >> 8)
 		encoded[3] = byte(handshakeLen)
-		encoded = append(encoded[:4], msgData...)
 
 		var got ClientHelloMsg
 		if got.Unmarshal(encoded) {

--- a/ftls/handshake_messages_test.go
+++ b/ftls/handshake_messages_test.go
@@ -1,6 +1,7 @@
 package ftls
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -369,4 +370,310 @@ func TestServerKeyExchangeMsgGetKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func hasExt(exts []uint16, want uint16) bool {
+	for _, ext := range exts {
+		if ext == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestClientHelloMarshalUnmarshalFull(t *testing.T) {
+	msg := &ClientHelloMsg{
+		Vers:               VersionTLS12,
+		Random:             bytes.Repeat([]byte{0xAB}, 32),
+		SessionId:          []byte{0x01, 0x02, 0x03, 0x04},
+		CipherSuites:       []uint16{0x1301, 0x1302, scsvRenegotiation},
+		CompressionMethods: []uint8{0x00},
+		ServerName:         "example.com",
+		OcspStapling:       true,
+		SupportedCurves:    []CurveID{X25519, CurveP256},
+		SupportedPoints:    []uint8{0x00},
+		TicketSupported:    true,
+		SessionTicket:      []uint8{0xAA, 0xBB},
+		SupportedSignatureAlgorithms: []SignatureScheme{
+			SignatureScheme(0x0403),
+			SignatureScheme(0x0804),
+		},
+		SupportedSignatureAlgorithmsCert: []SignatureScheme{
+			SignatureScheme(0x0805),
+		},
+		SecureRenegotiationSupported: true,
+		SecureRenegotiation:          []byte{0xFF},
+		ExtendedMasterSecret:         true,
+		AlpnProtocols:                []string{"h2", "http/1.1"},
+		Scts:                         true,
+		SupportedVersions:            []uint16{VersionTLS13, VersionTLS12},
+		Cookie:                       []byte{0x10, 0x11},
+		KeyShares: []KeyShare{{
+			Group: X25519,
+			Data:  []byte{1, 2, 3, 4},
+		}},
+		EarlyData:               true,
+		PskModes:                []uint8{0x01},
+		PskIdentities:           []PskIdentity{{Label: []byte("psk-id"), ObfuscatedTicketAge: 7}},
+		PskBinders:              [][]byte{{0x01, 0x02, 0x03}},
+		QuicTransportParameters: []byte{},
+		EncryptedClientHello:    []byte{0xEE, 0xCC},
+	}
+
+	encoded, err := msg.MarshalMsg(false)
+	if err != nil {
+		t.Fatalf("MarshalMsg() error = %v", err)
+	}
+
+	var got ClientHelloMsg
+	if !got.Unmarshal(encoded) {
+		t.Fatal("Unmarshal() returned false")
+	}
+
+	if got.Vers != msg.Vers {
+		t.Fatalf("version = %v, want %v", got.Vers, msg.Vers)
+	}
+
+	if !bytes.Equal(got.Random, msg.Random) {
+		t.Fatalf("random mismatch")
+	}
+
+	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported || !got.ExtendedMasterSecret || !got.Scts || !got.EarlyData {
+		t.Fatalf("expected boolean extensions to round-trip")
+	}
+
+	if got.ServerName != msg.ServerName {
+		t.Fatalf("server name = %q, want %q", got.ServerName, msg.ServerName)
+	}
+
+	if len(got.PskIdentities) != 1 || len(got.PskBinders) != 1 {
+		t.Fatalf("expected one PSK identity and binder")
+	}
+
+	if !hasExt(got.Extensions, ExtensionPreSharedKey) {
+		t.Fatalf("expected pre_shared_key extension to be present")
+	}
+}
+
+func TestClientHelloMarshalMsgECHInner(t *testing.T) {
+	msg := &ClientHelloMsg{
+		Vers:               VersionTLS13,
+		Random:             bytes.Repeat([]byte{0xCD}, 32),
+		SessionId:          []byte{0x99, 0x88, 0x77},
+		CipherSuites:       []uint16{0x1301},
+		CompressionMethods: []uint8{0x00},
+		OcspStapling:       true,
+		SupportedCurves:    []CurveID{X25519},
+		SupportedSignatureAlgorithms: []SignatureScheme{
+			SignatureScheme(0x0403),
+		},
+		AlpnProtocols:     []string{"h2"},
+		SupportedVersions: []uint16{VersionTLS13},
+		Cookie:            []byte{0xAA},
+		KeyShares:         []KeyShare{{Group: X25519, Data: []byte{0x01, 0x02}}},
+		PskModes:          []uint8{0x01},
+	}
+
+	encoded, err := msg.MarshalMsg(true)
+	if err != nil {
+		t.Fatalf("MarshalMsg(true) error = %v", err)
+	}
+
+	var got ClientHelloMsg
+	if !got.Unmarshal(encoded) {
+		t.Fatal("Unmarshal() returned false")
+	}
+
+	if len(got.SessionId) != 0 {
+		t.Fatalf("session id should be omitted for ECH inner")
+	}
+
+	if hasExt(got.Extensions, ExtensionStatusRequest) {
+		t.Fatalf("status_request should not be directly encoded for ECH inner")
+	}
+
+	if !hasExt(got.Extensions, ExtensionECHOuterExtensions) {
+		t.Fatalf("expected ech_outer_extensions extension")
+	}
+}
+
+func TestClientHelloUnmarshalRejectsInvalid(t *testing.T) {
+	t.Run("server name trailing dot", func(t *testing.T) {
+		msg := &ClientHelloMsg{
+			Vers:               VersionTLS12,
+			Random:             bytes.Repeat([]byte{0x11}, 32),
+			CipherSuites:       []uint16{0x1301},
+			CompressionMethods: []uint8{0x00},
+			ServerName:         "example.com.",
+		}
+
+		encoded, err := msg.MarshalMsg(false)
+		if err != nil {
+			t.Fatalf("MarshalMsg() error = %v", err)
+		}
+
+		var got ClientHelloMsg
+		if got.Unmarshal(encoded) {
+			t.Fatal("Unmarshal() expected false for trailing-dot SNI")
+		}
+	})
+
+	t.Run("pre shared key not last", func(t *testing.T) {
+		base := &ClientHelloMsg{
+			Vers:               VersionTLS13,
+			Random:             bytes.Repeat([]byte{0x22}, 32),
+			CipherSuites:       []uint16{0x1301},
+			CompressionMethods: []uint8{0x00},
+			PskIdentities:      []PskIdentity{{Label: []byte("a"), ObfuscatedTicketAge: 1}},
+			PskBinders:         [][]byte{{0x01}},
+		}
+
+		encoded, err := base.MarshalMsg(false)
+		if err != nil {
+			t.Fatalf("MarshalMsg() error = %v", err)
+		}
+
+		// Append an extra zero-length unknown extension after pre_shared_key
+		// while updating both handshake and extension length fields.
+		msgData := append([]byte(nil), encoded[4:]...)
+		extLenOffset := len(msgData) - 2
+		for i := 0; i+3 < len(msgData); i++ {
+			if i+1 < len(msgData) {
+				extLen := int(msgData[i])<<8 | int(msgData[i+1])
+				if i+2+extLen == len(msgData) {
+					extLenOffset = i
+					break
+				}
+			}
+		}
+
+		extLen := int(msgData[extLenOffset])<<8 | int(msgData[extLenOffset+1])
+		msgData[extLenOffset] = byte((extLen + 4) >> 8)
+		msgData[extLenOffset+1] = byte(extLen + 4)
+		msgData = append(msgData, 0xFA, 0xCE, 0x00, 0x00)
+
+		handshakeLen := len(msgData)
+		encoded[1] = byte(handshakeLen >> 16)
+		encoded[2] = byte(handshakeLen >> 8)
+		encoded[3] = byte(handshakeLen)
+		encoded = append(encoded[:4], msgData...)
+
+		var got ClientHelloMsg
+		if got.Unmarshal(encoded) {
+			t.Fatal("Unmarshal() expected false when pre_shared_key is not last")
+		}
+	})
+}
+
+func TestServerHelloMarshalUnmarshalWithExtensions(t *testing.T) {
+	msg := &ServerHelloMsg{
+		Vers:                         VersionTLS13,
+		Random:                       bytes.Repeat([]byte{0x33}, 32),
+		SessionId:                    []byte{0x01, 0x02},
+		CipherSuite:                  0x1301,
+		CompressionMethod:            0,
+		OcspStapling:                 true,
+		TicketSupported:              true,
+		SecureRenegotiationSupported: true,
+		SecureRenegotiation:          []byte{0xAA},
+		ExtendedMasterSecret:         true,
+		AlpnProtocol:                 "h2",
+		Scts:                         [][]byte{{0x01, 0x02}},
+		SupportedVersion:             VersionTLS13,
+		ServerShare:                  KeyShare{Group: X25519, Data: []byte{0x10, 0x20}},
+		SelectedIdentityPresent:      true,
+		SelectedIdentity:             2,
+		SupportedPoints:              []uint8{0x00},
+		EncryptedClientHello:         []byte{0xEE},
+		ServerNameAck:                true,
+		Cookie:                       []byte{0xCA, 0xFE},
+	}
+
+	encoded, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got ServerHelloMsg
+	if !got.Unmarshal(encoded) {
+		t.Fatal("Unmarshal() returned false")
+	}
+
+	if !got.OcspStapling || !got.TicketSupported || !got.SecureRenegotiationSupported || !got.ExtendedMasterSecret || !got.SelectedIdentityPresent || !got.ServerNameAck {
+		t.Fatalf("expected boolean extension flags to be set")
+	}
+
+	if got.SelectedIdentity != msg.SelectedIdentity || got.SupportedVersion != msg.SupportedVersion {
+		t.Fatalf("selected identity/version mismatch")
+	}
+
+	if got.ServerShare.Group != msg.ServerShare.Group || !bytes.Equal(got.ServerShare.Data, msg.ServerShare.Data) {
+		t.Fatalf("server share mismatch")
+	}
+
+	if !bytes.Equal(got.OriginalBytes(), encoded) {
+		t.Fatalf("OriginalBytes mismatch")
+	}
+}
+
+func TestServerHelloUnmarshalHelloRetryRequestKeyShare(t *testing.T) {
+	msg := &ServerHelloMsg{
+		Vers:              VersionTLS13,
+		Random:            bytes.Repeat([]byte{0x55}, 32),
+		CipherSuite:       0x1301,
+		CompressionMethod: 0,
+		SelectedGroup:     CurveP256,
+	}
+
+	encoded, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got ServerHelloMsg
+	if !got.Unmarshal(encoded) {
+		t.Fatal("Unmarshal() returned false")
+	}
+
+	if got.SelectedGroup != CurveP256 {
+		t.Fatalf("selected group = %v, want %v", got.SelectedGroup, CurveP256)
+	}
+}
+
+func TestServerKeyExchangeMarshalAndUnmarshal(t *testing.T) {
+	t.Run("marshal normal", func(t *testing.T) {
+		msg := &ServerKeyExchangeMsg{Key: []byte{0x01, 0x02, 0x03}}
+		encoded, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+
+		want := []byte{TypeServerKeyExchange, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03}
+		if !bytes.Equal(encoded, want) {
+			t.Fatalf("Marshal() = %v, want %v", encoded, want)
+		}
+	})
+
+	t.Run("marshal too large", func(t *testing.T) {
+		msg := &ServerKeyExchangeMsg{Key: make([]byte, 0x1000000)}
+		if _, err := msg.Marshal(); err == nil {
+			t.Fatal("Marshal() expected error for oversized key")
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		msg := &ServerKeyExchangeMsg{}
+		if msg.Unmarshal([]byte{TypeServerKeyExchange, 0x00, 0x00}) {
+			t.Fatal("Unmarshal() expected false for short message")
+		}
+
+		if !msg.Unmarshal([]byte{TypeServerKeyExchange, 0x00, 0x00, 0x01, 0xAA}) {
+			t.Fatal("Unmarshal() expected true")
+		}
+
+		if !bytes.Equal(msg.Key, []byte{0xAA}) {
+			t.Fatalf("unexpected key bytes: %v", msg.Key)
+		}
+	})
 }

--- a/ftls/handshake_messages_test.go
+++ b/ftls/handshake_messages_test.go
@@ -405,6 +405,7 @@ func clientHelloExtensionsLenOffset(handshake []byte) (int, error) {
 	}
 
 	sessionIDLen := int(handshake[pos])
+
 	pos++
 	if pos+sessionIDLen > len(handshake) {
 		return 0, fmt.Errorf("truncated session_id")
@@ -417,6 +418,7 @@ func clientHelloExtensionsLenOffset(handshake []byte) (int, error) {
 	}
 
 	cipherSuitesLen := int(handshake[pos])<<8 | int(handshake[pos+1])
+
 	pos += 2
 	if pos+cipherSuitesLen > len(handshake) {
 		return 0, fmt.Errorf("truncated cipher_suites")
@@ -429,6 +431,7 @@ func clientHelloExtensionsLenOffset(handshake []byte) (int, error) {
 	}
 
 	compressionMethodsLen := int(handshake[pos])
+
 	pos++
 	if pos+compressionMethodsLen > len(handshake) {
 		return 0, fmt.Errorf("truncated compression_methods")


### PR DESCRIPTION
This pull request significantly expands and improves the FTLS handshake message unit test coverage. It adds comprehensive tests for `ClientHello`, `ServerHello`, and `ServerKeyExchange` message marshaling and unmarshaling, covering a wide range of extension combinations and error cases. The documentation is updated to describe the new tests and provide instructions for running them.

**Testing improvements:**

* Added thorough unit tests to `ftls/handshake_messages_test.go` for `ClientHello`, `ServerHello`, and `ServerKeyExchange` messages, including round-trip encoding/decoding with all major TLS extensions, ECH inner/outer handling, and strict validation of malformed messages.
* Documented the new and existing FTLS handshake message tests in `TESTING.md`, detailing the test cases and extension coverage. [[1]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906L18-R18) [[2]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906R86-R138)

**Developer workflow enhancements:**

* Added example commands in `TESTING.md` for running only the FTLS handshake message tests and for generating per-file coverage reports.

**Minor improvements:**

* Added a helper function `hasExt` for extension presence checks in tests.
* Added missing `bytes` import required by new tests.